### PR TITLE
Fix memory issues related to freeverb

### DIFF
--- a/freeverb/allpass.hpp
+++ b/freeverb/allpass.hpp
@@ -21,12 +21,12 @@ public:
 
 	~allpass()
 	{
-		if (buffer) delete buffer;
+		if (buffer) delete[] buffer;
 	};
 
         void    makebuffer(float *buf, int size)
         {
-		if (buffer) delete buffer;
+		if (buffer) delete[] buffer;
                 buffer = new float[size];
                 bufsize = size;
 		bufidx = 0;
@@ -34,7 +34,7 @@ public:
 
         void    deletebuffer()
         {
-                if(buffer) delete buffer;
+                if(buffer) delete[] buffer;
                 bufsize = 0;
         };
 

--- a/freeverb/comb.hpp
+++ b/freeverb/comb.hpp
@@ -23,12 +23,12 @@ public:
 
 	~comb()
 	{
-		if (buffer) delete buffer;
+		if (buffer) delete[] buffer;
 	};
 
 	void    makebuffer(float *buf, int size) 
 	{
-		if (buffer) {delete buffer;}
+		if (buffer) {delete[] buffer;}
 		buffer = new float[size];
 		bufsize = size;
 		bufidx = 0;
@@ -36,7 +36,7 @@ public:
 
 	void	deletebuffer()
 	{
-		if(buffer) delete buffer;
+		if(buffer) delete[] buffer;
 		bufsize = 0;
 	};
 

--- a/freeverb/revmodel.cpp
+++ b/freeverb/revmodel.cpp
@@ -73,13 +73,16 @@ void revmodel::init(const float sampleRate)
 
 	feedback_allpass = 0.5;
 
-	setwet(initialwet);
-	setroomsize(initialroom);
-	setdry(initialdry);
-	setdamp(initialdamp);
-	setwidth(initialwidth);
-	setmode(initialmode);
+	// safely initialize all values first
+	wet = initialwet * scalewet;
+	roomsize = (initialroom * scaleroom) + offsetroom;
+	dry = initialdry * scaledry;
+	damp = initialdamp * scaledamp * sqrt(conversion) ;
+	width = initialwidth;
+	mode = initialmode;
 
+	// now we can call update after all values are initialized
+	update();
 
 	// Buffer will be full of rubbish - so we MUST mute them
 	mute();


### PR DESCRIPTION
As detected by valgrind, logs were:
```
==869036== Conditional jump or move depends on uninitialised value(s)
==869036==    at 0x1CCCD4C: MLrevmodel::update() (revmodel.cpp:141)
==869036==    by 0x1CCCF28: MLrevmodel::setwet(float) (revmodel.cpp:190)
==869036==    by 0x1CCC9F3: MLrevmodel::init(float) (revmodel.cpp:76)
==869036==    by 0x1C6AEA5: FreeVerb::FreeVerb() (FreeVerb.cpp:55)
==869036==    by 0x1C6BB83: rack::CardinalPluginModel<FreeVerb, FreeVerbWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Uninitialised value was created by a heap allocation
==869036==    at 0x6E8E013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1C6BB78: rack::CardinalPluginModel<FreeVerb, FreeVerbWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Conditional jump or move depends on uninitialised value(s)
==869036==    at 0x1CCCD4C: MLrevmodel::update() (revmodel.cpp:141)
==869036==    by 0x1CCCE16: MLrevmodel::setroomsize(float) (revmodel.cpp:165)
==869036==    by 0x1CCCA09: MLrevmodel::init(float) (revmodel.cpp:77)
==869036==    by 0x1C6AEA5: FreeVerb::FreeVerb() (FreeVerb.cpp:55)
==869036==    by 0x1C6BB83: rack::CardinalPluginModel<FreeVerb, FreeVerbWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Uninitialised value was created by a heap allocation
==869036==    at 0x6E8E013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1C6BB78: rack::CardinalPluginModel<FreeVerb, FreeVerbWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Conditional jump or move depends on uninitialised value(s)
==869036==    at 0x1CCCD4C: MLrevmodel::update() (revmodel.cpp:141)
==869036==    by 0x1CCCEC5: MLrevmodel::setdamp(float) (revmodel.cpp:178)
==869036==    by 0x1CCCA35: MLrevmodel::init(float) (revmodel.cpp:79)
==869036==    by 0x1C6AEA5: FreeVerb::FreeVerb() (FreeVerb.cpp:55)
==869036==    by 0x1C6BB83: rack::CardinalPluginModel<FreeVerb, FreeVerbWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Uninitialised value was created by a heap allocation
==869036==    at 0x6E8E013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1C6BB78: rack::CardinalPluginModel<FreeVerb, FreeVerbWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Conditional jump or move depends on uninitialised value(s)
==869036==    at 0x1CCCD4C: MLrevmodel::update() (revmodel.cpp:141)
==869036==    by 0x1CCCFC8: MLrevmodel::setwidth(float) (revmodel.cpp:211)
==869036==    by 0x1CCCA4B: MLrevmodel::init(float) (revmodel.cpp:80)
==869036==    by 0x1C6AEA5: FreeVerb::FreeVerb() (FreeVerb.cpp:55)
==869036==    by 0x1C6BB83: rack::CardinalPluginModel<FreeVerb, FreeVerbWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Uninitialised value was created by a heap allocation
==869036==    at 0x6E8E013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1C6BB78: rack::CardinalPluginModel<FreeVerb, FreeVerbWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Mismatched free() / delete / delete []
==869036==    at 0x6E908AF: operator delete(void*) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD0AE: MLcomb::makebuffer(float*, int) (comb.hpp:31)
==869036==    by 0x1CCC699: MLrevmodel::init(float) (revmodel.cpp:48)
==869036==    by 0x1C698AF: FreeVerb::onSampleRateChange() (FreeVerb.cpp:71)
==869036==    by 0x770346: rack::engine::Module::onSampleRateChange(rack::engine::Module::SampleRateChangeEvent const&) (Module.hpp:409)
==869036==    by 0x24A46CB: rack::engine::Engine::addModule(rack::engine::Module*) (Engine.cpp:616)
==869036==    by 0x6B3B5F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:495)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Address 0x216db4b0 is 0 bytes inside a block of size 4,464 alloc'd
==869036==    at 0x6E8F2F3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD0D5: MLcomb::makebuffer(float*, int) (comb.hpp:32)
==869036==    by 0x1CCC699: MLrevmodel::init(float) (revmodel.cpp:48)
==869036==    by 0x1C6AEA5: FreeVerb::FreeVerb() (FreeVerb.cpp:55)
==869036==    by 0x1C6BB83: rack::CardinalPluginModel<FreeVerb, FreeVerbWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Mismatched free() / delete / delete []
==869036==    at 0x6E908AF: operator delete(void*) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD0AE: MLcomb::makebuffer(float*, int) (comb.hpp:31)
==869036==    by 0x1CCC6BD: MLrevmodel::init(float) (revmodel.cpp:49)
==869036==    by 0x1C698AF: FreeVerb::onSampleRateChange() (FreeVerb.cpp:71)
==869036==    by 0x770346: rack::engine::Module::onSampleRateChange(rack::engine::Module::SampleRateChangeEvent const&) (Module.hpp:409)
==869036==    by 0x24A46CB: rack::engine::Engine::addModule(rack::engine::Module*) (Engine.cpp:616)
==869036==    by 0x6B3B5F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:495)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Address 0x216dc660 is 0 bytes inside a block of size 4,556 alloc'd
==869036==    at 0x6E8F2F3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD0D5: MLcomb::makebuffer(float*, int) (comb.hpp:32)
==869036==    by 0x1CCC6BD: MLrevmodel::init(float) (revmodel.cpp:49)
==869036==    by 0x1C6AEA5: FreeVerb::FreeVerb() (FreeVerb.cpp:55)
==869036==    by 0x1C6BB83: rack::CardinalPluginModel<FreeVerb, FreeVerbWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Mismatched free() / delete / delete []
==869036==    at 0x6E908AF: operator delete(void*) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD0AE: MLcomb::makebuffer(float*, int) (comb.hpp:31)
==869036==    by 0x1CCC6DE: MLrevmodel::init(float) (revmodel.cpp:50)
==869036==    by 0x1C698AF: FreeVerb::onSampleRateChange() (FreeVerb.cpp:71)
==869036==    by 0x770346: rack::engine::Module::onSampleRateChange(rack::engine::Module::SampleRateChangeEvent const&) (Module.hpp:409)
==869036==    by 0x24A46CB: rack::engine::Engine::addModule(rack::engine::Module*) (Engine.cpp:616)
==869036==    by 0x6B3B5F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:495)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Address 0x216dd870 is 0 bytes inside a block of size 4,752 alloc'd
==869036==    at 0x6E8F2F3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD0D5: MLcomb::makebuffer(float*, int) (comb.hpp:32)
==869036==    by 0x1CCC6DE: MLrevmodel::init(float) (revmodel.cpp:50)
==869036==    by 0x1C6AEA5: FreeVerb::FreeVerb() (FreeVerb.cpp:55)
==869036==    by 0x1C6BB83: rack::CardinalPluginModel<FreeVerb, FreeVerbWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Mismatched free() / delete / delete []
==869036==    at 0x6E908AF: operator delete(void*) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD0AE: MLcomb::makebuffer(float*, int) (comb.hpp:31)
==869036==    by 0x1CCC702: MLrevmodel::init(float) (revmodel.cpp:51)
==869036==    by 0x1C698AF: FreeVerb::onSampleRateChange() (FreeVerb.cpp:71)
==869036==    by 0x770346: rack::engine::Module::onSampleRateChange(rack::engine::Module::SampleRateChangeEvent const&) (Module.hpp:409)
==869036==    by 0x24A46CB: rack::engine::Engine::addModule(rack::engine::Module*) (Engine.cpp:616)
==869036==    by 0x6B3B5F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:495)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Address 0x2228a650 is 0 bytes inside a block of size 4,844 alloc'd
==869036==    at 0x6E8F2F3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD0D5: MLcomb::makebuffer(float*, int) (comb.hpp:32)
==869036==    by 0x1CCC702: MLrevmodel::init(float) (revmodel.cpp:51)
==869036==    by 0x1C6AEA5: FreeVerb::FreeVerb() (FreeVerb.cpp:55)
==869036==    by 0x1C6BB83: rack::CardinalPluginModel<FreeVerb, FreeVerbWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Mismatched free() / delete / delete []
==869036==    at 0x6E908AF: operator delete(void*) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD0AE: MLcomb::makebuffer(float*, int) (comb.hpp:31)
==869036==    by 0x1CCC723: MLrevmodel::init(float) (revmodel.cpp:52)
==869036==    by 0x1C698AF: FreeVerb::onSampleRateChange() (FreeVerb.cpp:71)
==869036==    by 0x770346: rack::engine::Module::onSampleRateChange(rack::engine::Module::SampleRateChangeEvent const&) (Module.hpp:409)
==869036==    by 0x24A46CB: rack::engine::Engine::addModule(rack::engine::Module*) (Engine.cpp:616)
==869036==    by 0x6B3B5F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:495)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Address 0x2228b980 is 0 bytes inside a block of size 5,108 alloc'd
==869036==    at 0x6E8F2F3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD0D5: MLcomb::makebuffer(float*, int) (comb.hpp:32)
==869036==    by 0x1CCC723: MLrevmodel::init(float) (revmodel.cpp:52)
==869036==    by 0x1C6AEA5: FreeVerb::FreeVerb() (FreeVerb.cpp:55)
==869036==    by 0x1C6BB83: rack::CardinalPluginModel<FreeVerb, FreeVerbWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Mismatched free() / delete / delete []
==869036==    at 0x6E908AF: operator delete(void*) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD0AE: MLcomb::makebuffer(float*, int) (comb.hpp:31)
==869036==    by 0x1CCC747: MLrevmodel::init(float) (revmodel.cpp:53)
==869036==    by 0x1C698AF: FreeVerb::onSampleRateChange() (FreeVerb.cpp:71)
==869036==    by 0x770346: rack::engine::Module::onSampleRateChange(rack::engine::Module::SampleRateChangeEvent const&) (Module.hpp:409)
==869036==    by 0x24A46CB: rack::engine::Engine::addModule(rack::engine::Module*) (Engine.cpp:616)
==869036==    by 0x6B3B5F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:495)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Address 0x2228cdc0 is 0 bytes inside a block of size 5,200 alloc'd
==869036==    at 0x6E8F2F3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD0D5: MLcomb::makebuffer(float*, int) (comb.hpp:32)
==869036==    by 0x1CCC747: MLrevmodel::init(float) (revmodel.cpp:53)
==869036==    by 0x1C6AEA5: FreeVerb::FreeVerb() (FreeVerb.cpp:55)
==869036==    by 0x1C6BB83: rack::CardinalPluginModel<FreeVerb, FreeVerbWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Mismatched free() / delete / delete []
==869036==    at 0x6E908AF: operator delete(void*) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD0AE: MLcomb::makebuffer(float*, int) (comb.hpp:31)
==869036==    by 0x1CCC768: MLrevmodel::init(float) (revmodel.cpp:54)
==869036==    by 0x1C698AF: FreeVerb::onSampleRateChange() (FreeVerb.cpp:71)
==869036==    by 0x770346: rack::engine::Module::onSampleRateChange(rack::engine::Module::SampleRateChangeEvent const&) (Module.hpp:409)
==869036==    by 0x24A46CB: rack::engine::Engine::addModule(rack::engine::Module*) (Engine.cpp:616)
==869036==    by 0x6B3B5F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:495)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Address 0x2228e250 is 0 bytes inside a block of size 5,424 alloc'd
==869036==    at 0x6E8F2F3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD0D5: MLcomb::makebuffer(float*, int) (comb.hpp:32)
==869036==    by 0x1CCC768: MLrevmodel::init(float) (revmodel.cpp:54)
==869036==    by 0x1C6AEA5: FreeVerb::FreeVerb() (FreeVerb.cpp:55)
==869036==    by 0x1C6BB83: rack::CardinalPluginModel<FreeVerb, FreeVerbWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Mismatched free() / delete / delete []
==869036==    at 0x6E908AF: operator delete(void*) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD0AE: MLcomb::makebuffer(float*, int) (comb.hpp:31)
==869036==    by 0x1CCC78C: MLrevmodel::init(float) (revmodel.cpp:55)
==869036==    by 0x1C698AF: FreeVerb::onSampleRateChange() (FreeVerb.cpp:71)
==869036==    by 0x770346: rack::engine::Module::onSampleRateChange(rack::engine::Module::SampleRateChangeEvent const&) (Module.hpp:409)
==869036==    by 0x24A46CB: rack::engine::Engine::addModule(rack::engine::Module*) (Engine.cpp:616)
==869036==    by 0x6B3B5F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:495)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Address 0x2228f7c0 is 0 bytes inside a block of size 5,516 alloc'd
==869036==    at 0x6E8F2F3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD0D5: MLcomb::makebuffer(float*, int) (comb.hpp:32)
==869036==    by 0x1CCC78C: MLrevmodel::init(float) (revmodel.cpp:55)
==869036==    by 0x1C6AEA5: FreeVerb::FreeVerb() (FreeVerb.cpp:55)
==869036==    by 0x1C6BB83: rack::CardinalPluginModel<FreeVerb, FreeVerbWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Mismatched free() / delete / delete []
==869036==    at 0x6E908AF: operator delete(void*) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD0AE: MLcomb::makebuffer(float*, int) (comb.hpp:31)
==869036==    by 0x1CCC7B0: MLrevmodel::init(float) (revmodel.cpp:56)
==869036==    by 0x1C698AF: FreeVerb::onSampleRateChange() (FreeVerb.cpp:71)
==869036==    by 0x770346: rack::engine::Module::onSampleRateChange(rack::engine::Module::SampleRateChangeEvent const&) (Module.hpp:409)
==869036==    by 0x24A46CB: rack::engine::Engine::addModule(rack::engine::Module*) (Engine.cpp:616)
==869036==    by 0x6B3B5F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:495)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Address 0x22290d90 is 0 bytes inside a block of size 5,688 alloc'd
==869036==    at 0x6E8F2F3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD0D5: MLcomb::makebuffer(float*, int) (comb.hpp:32)
==869036==    by 0x1CCC7B0: MLrevmodel::init(float) (revmodel.cpp:56)
==869036==    by 0x1C6AEA5: FreeVerb::FreeVerb() (FreeVerb.cpp:55)
==869036==    by 0x1C6BB83: rack::CardinalPluginModel<FreeVerb, FreeVerbWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Mismatched free() / delete / delete []
==869036==    at 0x6E908AF: operator delete(void*) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD0AE: MLcomb::makebuffer(float*, int) (comb.hpp:31)
==869036==    by 0x1CCC7D4: MLrevmodel::init(float) (revmodel.cpp:57)
==869036==    by 0x1C698AF: FreeVerb::onSampleRateChange() (FreeVerb.cpp:71)
==869036==    by 0x770346: rack::engine::Module::onSampleRateChange(rack::engine::Module::SampleRateChangeEvent const&) (Module.hpp:409)
==869036==    by 0x24A46CB: rack::engine::Engine::addModule(rack::engine::Module*) (Engine.cpp:616)
==869036==    by 0x6B3B5F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:495)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Address 0x22292410 is 0 bytes inside a block of size 5,780 alloc'd
==869036==    at 0x6E8F2F3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD0D5: MLcomb::makebuffer(float*, int) (comb.hpp:32)
==869036==    by 0x1CCC7D4: MLrevmodel::init(float) (revmodel.cpp:57)
==869036==    by 0x1C6AEA5: FreeVerb::FreeVerb() (FreeVerb.cpp:55)
==869036==    by 0x1C6BB83: rack::CardinalPluginModel<FreeVerb, FreeVerbWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Mismatched free() / delete / delete []
==869036==    at 0x6E908AF: operator delete(void*) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD0AE: MLcomb::makebuffer(float*, int) (comb.hpp:31)
==869036==    by 0x1CCC7F8: MLrevmodel::init(float) (revmodel.cpp:58)
==869036==    by 0x1C698AF: FreeVerb::onSampleRateChange() (FreeVerb.cpp:71)
==869036==    by 0x770346: rack::engine::Module::onSampleRateChange(rack::engine::Module::SampleRateChangeEvent const&) (Module.hpp:409)
==869036==    by 0x24A46CB: rack::engine::Engine::addModule(rack::engine::Module*) (Engine.cpp:616)
==869036==    by 0x6B3B5F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:495)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Address 0x21769950 is 0 bytes inside a block of size 5,964 alloc'd
==869036==    at 0x6E8F2F3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD0D5: MLcomb::makebuffer(float*, int) (comb.hpp:32)
==869036==    by 0x1CCC7F8: MLrevmodel::init(float) (revmodel.cpp:58)
==869036==    by 0x1C6AEA5: FreeVerb::FreeVerb() (FreeVerb.cpp:55)
==869036==    by 0x1C6BB83: rack::CardinalPluginModel<FreeVerb, FreeVerbWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Mismatched free() / delete / delete []
==869036==    at 0x6E908AF: operator delete(void*) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD0AE: MLcomb::makebuffer(float*, int) (comb.hpp:31)
==869036==    by 0x1CCC81C: MLrevmodel::init(float) (revmodel.cpp:59)
==869036==    by 0x1C698AF: FreeVerb::onSampleRateChange() (FreeVerb.cpp:71)
==869036==    by 0x770346: rack::engine::Module::onSampleRateChange(rack::engine::Module::SampleRateChangeEvent const&) (Module.hpp:409)
==869036==    by 0x24A46CB: rack::engine::Engine::addModule(rack::engine::Module*) (Engine.cpp:616)
==869036==    by 0x6B3B5F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:495)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Address 0x220c07f0 is 0 bytes inside a block of size 6,056 alloc'd
==869036==    at 0x6E8F2F3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD0D5: MLcomb::makebuffer(float*, int) (comb.hpp:32)
==869036==    by 0x1CCC81C: MLrevmodel::init(float) (revmodel.cpp:59)
==869036==    by 0x1C6AEA5: FreeVerb::FreeVerb() (FreeVerb.cpp:55)
==869036==    by 0x1C6BB83: rack::CardinalPluginModel<FreeVerb, FreeVerbWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Mismatched free() / delete / delete []
==869036==    at 0x6E908AF: operator delete(void*) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD0AE: MLcomb::makebuffer(float*, int) (comb.hpp:31)
==869036==    by 0x1CCC840: MLrevmodel::init(float) (revmodel.cpp:60)
==869036==    by 0x1C698AF: FreeVerb::onSampleRateChange() (FreeVerb.cpp:71)
==869036==    by 0x770346: rack::engine::Module::onSampleRateChange(rack::engine::Module::SampleRateChangeEvent const&) (Module.hpp:409)
==869036==    by 0x24A46CB: rack::engine::Engine::addModule(rack::engine::Module*) (Engine.cpp:616)
==869036==    by 0x6B3B5F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:495)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Address 0x2176b0e0 is 0 bytes inside a block of size 6,228 alloc'd
==869036==    at 0x6E8F2F3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD0D5: MLcomb::makebuffer(float*, int) (comb.hpp:32)
==869036==    by 0x1CCC840: MLrevmodel::init(float) (revmodel.cpp:60)
==869036==    by 0x1C6AEA5: FreeVerb::FreeVerb() (FreeVerb.cpp:55)
==869036==    by 0x1C6BB83: rack::CardinalPluginModel<FreeVerb, FreeVerbWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Mismatched free() / delete / delete []
==869036==    at 0x6E908AF: operator delete(void*) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD0AE: MLcomb::makebuffer(float*, int) (comb.hpp:31)
==869036==    by 0x1CCC864: MLrevmodel::init(float) (revmodel.cpp:61)
==869036==    by 0x1C698AF: FreeVerb::onSampleRateChange() (FreeVerb.cpp:71)
==869036==    by 0x770346: rack::engine::Module::onSampleRateChange(rack::engine::Module::SampleRateChangeEvent const&) (Module.hpp:409)
==869036==    by 0x24A46CB: rack::engine::Engine::addModule(rack::engine::Module*) (Engine.cpp:616)
==869036==    by 0x6B3B5F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:495)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Address 0x220c1fe0 is 0 bytes inside a block of size 6,320 alloc'd
==869036==    at 0x6E8F2F3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD0D5: MLcomb::makebuffer(float*, int) (comb.hpp:32)
==869036==    by 0x1CCC864: MLrevmodel::init(float) (revmodel.cpp:61)
==869036==    by 0x1C6AEA5: FreeVerb::FreeVerb() (FreeVerb.cpp:55)
==869036==    by 0x1C6BB83: rack::CardinalPluginModel<FreeVerb, FreeVerbWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Mismatched free() / delete / delete []
==869036==    at 0x6E908AF: operator delete(void*) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD0AE: MLcomb::makebuffer(float*, int) (comb.hpp:31)
==869036==    by 0x1CCC888: MLrevmodel::init(float) (revmodel.cpp:62)
==869036==    by 0x1C698AF: FreeVerb::onSampleRateChange() (FreeVerb.cpp:71)
==869036==    by 0x770346: rack::engine::Module::onSampleRateChange(rack::engine::Module::SampleRateChangeEvent const&) (Module.hpp:409)
==869036==    by 0x24A46CB: rack::engine::Engine::addModule(rack::engine::Module*) (Engine.cpp:616)
==869036==    by 0x6B3B5F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:495)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Address 0x2176c980 is 0 bytes inside a block of size 6,468 alloc'd
==869036==    at 0x6E8F2F3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD0D5: MLcomb::makebuffer(float*, int) (comb.hpp:32)
==869036==    by 0x1CCC888: MLrevmodel::init(float) (revmodel.cpp:62)
==869036==    by 0x1C6AEA5: FreeVerb::FreeVerb() (FreeVerb.cpp:55)
==869036==    by 0x1C6BB83: rack::CardinalPluginModel<FreeVerb, FreeVerbWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Mismatched free() / delete / delete []
==869036==    at 0x6E908AF: operator delete(void*) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD0AE: MLcomb::makebuffer(float*, int) (comb.hpp:31)
==869036==    by 0x1CCC8AC: MLrevmodel::init(float) (revmodel.cpp:63)
==869036==    by 0x1C698AF: FreeVerb::onSampleRateChange() (FreeVerb.cpp:71)
==869036==    by 0x770346: rack::engine::Module::onSampleRateChange(rack::engine::Module::SampleRateChangeEvent const&) (Module.hpp:409)
==869036==    by 0x24A46CB: rack::engine::Engine::addModule(rack::engine::Module*) (Engine.cpp:616)
==869036==    by 0x6B3B5F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:495)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Address 0x220c38d0 is 0 bytes inside a block of size 6,560 alloc'd
==869036==    at 0x6E8F2F3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD0D5: MLcomb::makebuffer(float*, int) (comb.hpp:32)
==869036==    by 0x1CCC8AC: MLrevmodel::init(float) (revmodel.cpp:63)
==869036==    by 0x1C6AEA5: FreeVerb::FreeVerb() (FreeVerb.cpp:55)
==869036==    by 0x1C6BB83: rack::CardinalPluginModel<FreeVerb, FreeVerbWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Mismatched free() / delete / delete []
==869036==    at 0x6E908AF: operator delete(void*) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD278: MLallpass::makebuffer(float*, int) (allpass.hpp:29)
==869036==    by 0x1CCC8D0: MLrevmodel::init(float) (revmodel.cpp:65)
==869036==    by 0x1C698AF: FreeVerb::onSampleRateChange() (FreeVerb.cpp:71)
==869036==    by 0x770346: rack::engine::Module::onSampleRateChange(rack::engine::Module::SampleRateChangeEvent const&) (Module.hpp:409)
==869036==    by 0x24A46CB: rack::engine::Engine::addModule(rack::engine::Module*) (Engine.cpp:616)
==869036==    by 0x6B3B5F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:495)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Address 0x1fd9e7e0 is 0 bytes inside a block of size 2,224 alloc'd
==869036==    at 0x6E8F2F3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD29F: MLallpass::makebuffer(float*, int) (allpass.hpp:30)
==869036==    by 0x1CCC8D0: MLrevmodel::init(float) (revmodel.cpp:65)
==869036==    by 0x1C6AEA5: FreeVerb::FreeVerb() (FreeVerb.cpp:55)
==869036==    by 0x1C6BB83: rack::CardinalPluginModel<FreeVerb, FreeVerbWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Mismatched free() / delete / delete []
==869036==    at 0x6E908AF: operator delete(void*) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD278: MLallpass::makebuffer(float*, int) (allpass.hpp:29)
==869036==    by 0x1CCC8F4: MLrevmodel::init(float) (revmodel.cpp:66)
==869036==    by 0x1C698AF: FreeVerb::onSampleRateChange() (FreeVerb.cpp:71)
==869036==    by 0x770346: rack::engine::Module::onSampleRateChange(rack::engine::Module::SampleRateChangeEvent const&) (Module.hpp:409)
==869036==    by 0x24A46CB: rack::engine::Engine::addModule(rack::engine::Module*) (Engine.cpp:616)
==869036==    by 0x6B3B5F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:495)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Address 0x1fdc36c0 is 0 bytes inside a block of size 2,316 alloc'd
==869036==    at 0x6E8F2F3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD29F: MLallpass::makebuffer(float*, int) (allpass.hpp:30)
==869036==    by 0x1CCC8F4: MLrevmodel::init(float) (revmodel.cpp:66)
==869036==    by 0x1C6AEA5: FreeVerb::FreeVerb() (FreeVerb.cpp:55)
==869036==    by 0x1C6BB83: rack::CardinalPluginModel<FreeVerb, FreeVerbWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Mismatched free() / delete / delete []
==869036==    at 0x6E908AF: operator delete(void*) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD278: MLallpass::makebuffer(float*, int) (allpass.hpp:29)
==869036==    by 0x1CCC918: MLrevmodel::init(float) (revmodel.cpp:67)
==869036==    by 0x1C698AF: FreeVerb::onSampleRateChange() (FreeVerb.cpp:71)
==869036==    by 0x770346: rack::engine::Module::onSampleRateChange(rack::engine::Module::SampleRateChangeEvent const&) (Module.hpp:409)
==869036==    by 0x24A46CB: rack::engine::Engine::addModule(rack::engine::Module*) (Engine.cpp:616)
==869036==    by 0x6B3B5F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:495)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Address 0x1f759390 is 0 bytes inside a block of size 1,764 alloc'd
==869036==    at 0x6E8F2F3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD29F: MLallpass::makebuffer(float*, int) (allpass.hpp:30)
==869036==    by 0x1CCC918: MLrevmodel::init(float) (revmodel.cpp:67)
==869036==    by 0x1C6AEA5: FreeVerb::FreeVerb() (FreeVerb.cpp:55)
==869036==    by 0x1C6BB83: rack::CardinalPluginModel<FreeVerb, FreeVerbWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Mismatched free() / delete / delete []
==869036==    at 0x6E908AF: operator delete(void*) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD278: MLallpass::makebuffer(float*, int) (allpass.hpp:29)
==869036==    by 0x1CCC93C: MLrevmodel::init(float) (revmodel.cpp:68)
==869036==    by 0x1C698AF: FreeVerb::onSampleRateChange() (FreeVerb.cpp:71)
==869036==    by 0x770346: rack::engine::Module::onSampleRateChange(rack::engine::Module::SampleRateChangeEvent const&) (Module.hpp:409)
==869036==    by 0x24A46CB: rack::engine::Engine::addModule(rack::engine::Module*) (Engine.cpp:616)
==869036==    by 0x6B3B5F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:495)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Address 0x1fd88ff0 is 0 bytes inside a block of size 1,856 alloc'd
==869036==    at 0x6E8F2F3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD29F: MLallpass::makebuffer(float*, int) (allpass.hpp:30)
==869036==    by 0x1CCC93C: MLrevmodel::init(float) (revmodel.cpp:68)
==869036==    by 0x1C6AEA5: FreeVerb::FreeVerb() (FreeVerb.cpp:55)
==869036==    by 0x1C6BB83: rack::CardinalPluginModel<FreeVerb, FreeVerbWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Mismatched free() / delete / delete []
==869036==    at 0x6E908AF: operator delete(void*) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD278: MLallpass::makebuffer(float*, int) (allpass.hpp:29)
==869036==    by 0x1CCC960: MLrevmodel::init(float) (revmodel.cpp:69)
==869036==    by 0x1C698AF: FreeVerb::onSampleRateChange() (FreeVerb.cpp:71)
==869036==    by 0x770346: rack::engine::Module::onSampleRateChange(rack::engine::Module::SampleRateChangeEvent const&) (Module.hpp:409)
==869036==    by 0x24A46CB: rack::engine::Engine::addModule(rack::engine::Module*) (Engine.cpp:616)
==869036==    by 0x6B3B5F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:495)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Address 0x15a7b6f0 is 0 bytes inside a block of size 1,364 alloc'd
==869036==    at 0x6E8F2F3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD29F: MLallpass::makebuffer(float*, int) (allpass.hpp:30)
==869036==    by 0x1CCC960: MLrevmodel::init(float) (revmodel.cpp:69)
==869036==    by 0x1C6AEA5: FreeVerb::FreeVerb() (FreeVerb.cpp:55)
==869036==    by 0x1C6BB83: rack::CardinalPluginModel<FreeVerb, FreeVerbWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Mismatched free() / delete / delete []
==869036==    at 0x6E908AF: operator delete(void*) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD278: MLallpass::makebuffer(float*, int) (allpass.hpp:29)
==869036==    by 0x1CCC984: MLrevmodel::init(float) (revmodel.cpp:70)
==869036==    by 0x1C698AF: FreeVerb::onSampleRateChange() (FreeVerb.cpp:71)
==869036==    by 0x770346: rack::engine::Module::onSampleRateChange(rack::engine::Module::SampleRateChangeEvent const&) (Module.hpp:409)
==869036==    by 0x24A46CB: rack::engine::Engine::addModule(rack::engine::Module*) (Engine.cpp:616)
==869036==    by 0x6B3B5F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:495)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Address 0x1f771890 is 0 bytes inside a block of size 1,456 alloc'd
==869036==    at 0x6E8F2F3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD29F: MLallpass::makebuffer(float*, int) (allpass.hpp:30)
==869036==    by 0x1CCC984: MLrevmodel::init(float) (revmodel.cpp:70)
==869036==    by 0x1C6AEA5: FreeVerb::FreeVerb() (FreeVerb.cpp:55)
==869036==    by 0x1C6BB83: rack::CardinalPluginModel<FreeVerb, FreeVerbWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Mismatched free() / delete / delete []
==869036==    at 0x6E908AF: operator delete(void*) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD278: MLallpass::makebuffer(float*, int) (allpass.hpp:29)
==869036==    by 0x1CCC9A8: MLrevmodel::init(float) (revmodel.cpp:71)
==869036==    by 0x1C698AF: FreeVerb::onSampleRateChange() (FreeVerb.cpp:71)
==869036==    by 0x770346: rack::engine::Module::onSampleRateChange(rack::engine::Module::SampleRateChangeEvent const&) (Module.hpp:409)
==869036==    by 0x24A46CB: rack::engine::Engine::addModule(rack::engine::Module*) (Engine.cpp:616)
==869036==    by 0x6B3B5F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:495)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Address 0x217a0d20 is 0 bytes inside a block of size 900 alloc'd
==869036==    at 0x6E8F2F3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD29F: MLallpass::makebuffer(float*, int) (allpass.hpp:30)
==869036==    by 0x1CCC9A8: MLrevmodel::init(float) (revmodel.cpp:71)
==869036==    by 0x1C6AEA5: FreeVerb::FreeVerb() (FreeVerb.cpp:55)
==869036==    by 0x1C6BB83: rack::CardinalPluginModel<FreeVerb, FreeVerbWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Mismatched free() / delete / delete []
==869036==    at 0x6E908AF: operator delete(void*) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD278: MLallpass::makebuffer(float*, int) (allpass.hpp:29)
==869036==    by 0x1CCC9CC: MLrevmodel::init(float) (revmodel.cpp:72)
==869036==    by 0x1C698AF: FreeVerb::onSampleRateChange() (FreeVerb.cpp:71)
==869036==    by 0x770346: rack::engine::Module::onSampleRateChange(rack::engine::Module::SampleRateChangeEvent const&) (Module.hpp:409)
==869036==    by 0x24A46CB: rack::engine::Engine::addModule(rack::engine::Module*) (Engine.cpp:616)
==869036==    by 0x6B3B5F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:495)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Address 0x1ebc8cc0 is 0 bytes inside a block of size 992 alloc'd
==869036==    at 0x6E8F2F3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD29F: MLallpass::makebuffer(float*, int) (allpass.hpp:30)
==869036==    by 0x1CCC9CC: MLrevmodel::init(float) (revmodel.cpp:72)
==869036==    by 0x1C6AEA5: FreeVerb::FreeVerb() (FreeVerb.cpp:55)
==869036==    by 0x1C6BB83: rack::CardinalPluginModel<FreeVerb, FreeVerbWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Mismatched free() / delete / delete []
==869036==    at 0x6E908AF: operator delete(void*) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1C6A8FD: MLallpass::~MLallpass() (allpass.hpp:24)
==869036==    by 0x1C6A94A: MLrevmodel::~MLrevmodel() (revmodel.hpp:18)
==869036==    by 0x1C6BB21: FreeVerb::~FreeVerb() (FreeVerb.cpp:5)
==869036==    by 0x1C6BB4D: FreeVerb::~FreeVerb() (FreeVerb.cpp:5)
==869036==    by 0x253B9BA: rack::app::ModuleWidget::setModule(rack::engine::Module*) (ModuleWidget.cpp:70)
==869036==    by 0x253B88E: rack::app::ModuleWidget::~ModuleWidget() (ModuleWidget.cpp:50)
==869036==    by 0x770B3F: rack::app::CardinalModuleWidget::~CardinalModuleWidget() (rack.hpp:25)
==869036==    by 0x1C6BABF: FreeVerbWidget::~FreeVerbWidget() (FreeVerb.cpp:127)
==869036==    by 0x1C6BADF: FreeVerbWidget::~FreeVerbWidget() (FreeVerb.cpp:127)
==869036==    by 0x6B3CB2: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:508)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==  Address 0x1fde3640 is 0 bytes inside a block of size 992 alloc'd
==869036==    at 0x6E8F2F3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD29F: MLallpass::makebuffer(float*, int) (allpass.hpp:30)
==869036==    by 0x1CCC9CC: MLrevmodel::init(float) (revmodel.cpp:72)
==869036==    by 0x1C698AF: FreeVerb::onSampleRateChange() (FreeVerb.cpp:71)
==869036==    by 0x770346: rack::engine::Module::onSampleRateChange(rack::engine::Module::SampleRateChangeEvent const&) (Module.hpp:409)
==869036==    by 0x24A46CB: rack::engine::Engine::addModule(rack::engine::Module*) (Engine.cpp:616)
==869036==    by 0x6B3B5F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:495)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Mismatched free() / delete / delete []
==869036==    at 0x6E908AF: operator delete(void*) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1C6A8FD: MLallpass::~MLallpass() (allpass.hpp:24)
==869036==    by 0x1C6A984: MLrevmodel::~MLrevmodel() (revmodel.hpp:18)
==869036==    by 0x1C6BB21: FreeVerb::~FreeVerb() (FreeVerb.cpp:5)
==869036==    by 0x1C6BB4D: FreeVerb::~FreeVerb() (FreeVerb.cpp:5)
==869036==    by 0x253B9BA: rack::app::ModuleWidget::setModule(rack::engine::Module*) (ModuleWidget.cpp:70)
==869036==    by 0x253B88E: rack::app::ModuleWidget::~ModuleWidget() (ModuleWidget.cpp:50)
==869036==    by 0x770B3F: rack::app::CardinalModuleWidget::~CardinalModuleWidget() (rack.hpp:25)
==869036==    by 0x1C6BABF: FreeVerbWidget::~FreeVerbWidget() (FreeVerb.cpp:127)
==869036==    by 0x1C6BADF: FreeVerbWidget::~FreeVerbWidget() (FreeVerb.cpp:127)
==869036==    by 0x6B3CB2: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:508)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==  Address 0x1fde8fe0 is 0 bytes inside a block of size 900 alloc'd
==869036==    at 0x6E8F2F3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD29F: MLallpass::makebuffer(float*, int) (allpass.hpp:30)
==869036==    by 0x1CCC9A8: MLrevmodel::init(float) (revmodel.cpp:71)
==869036==    by 0x1C698AF: FreeVerb::onSampleRateChange() (FreeVerb.cpp:71)
==869036==    by 0x770346: rack::engine::Module::onSampleRateChange(rack::engine::Module::SampleRateChangeEvent const&) (Module.hpp:409)
==869036==    by 0x24A46CB: rack::engine::Engine::addModule(rack::engine::Module*) (Engine.cpp:616)
==869036==    by 0x6B3B5F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:495)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Mismatched free() / delete / delete []
==869036==    at 0x6E908AF: operator delete(void*) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1C6A8C9: MLcomb::~MLcomb() (comb.hpp:26)
==869036==    by 0x1C6A9C1: MLrevmodel::~MLrevmodel() (revmodel.hpp:18)
==869036==    by 0x1C6BB21: FreeVerb::~FreeVerb() (FreeVerb.cpp:5)
==869036==    by 0x1C6BB4D: FreeVerb::~FreeVerb() (FreeVerb.cpp:5)
==869036==    by 0x253B9BA: rack::app::ModuleWidget::setModule(rack::engine::Module*) (ModuleWidget.cpp:70)
==869036==    by 0x253B88E: rack::app::ModuleWidget::~ModuleWidget() (ModuleWidget.cpp:50)
==869036==    by 0x770B3F: rack::app::CardinalModuleWidget::~CardinalModuleWidget() (rack.hpp:25)
==869036==    by 0x1C6BABF: FreeVerbWidget::~FreeVerbWidget() (FreeVerb.cpp:127)
==869036==    by 0x1C6BADF: FreeVerbWidget::~FreeVerbWidget() (FreeVerb.cpp:127)
==869036==    by 0x6B3CB2: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:508)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==  Address 0x217af910 is 0 bytes inside a block of size 6,560 alloc'd
==869036==    at 0x6E8F2F3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD0D5: MLcomb::makebuffer(float*, int) (comb.hpp:32)
==869036==    by 0x1CCC8AC: MLrevmodel::init(float) (revmodel.cpp:63)
==869036==    by 0x1C698AF: FreeVerb::onSampleRateChange() (FreeVerb.cpp:71)
==869036==    by 0x770346: rack::engine::Module::onSampleRateChange(rack::engine::Module::SampleRateChangeEvent const&) (Module.hpp:409)
==869036==    by 0x24A46CB: rack::engine::Engine::addModule(rack::engine::Module*) (Engine.cpp:616)
==869036==    by 0x6B3B5F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:495)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Mismatched free() / delete / delete []
==869036==    at 0x6E908AF: operator delete(void*) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1C6A8C9: MLcomb::~MLcomb() (comb.hpp:26)
==869036==    by 0x1C6A9F8: MLrevmodel::~MLrevmodel() (revmodel.hpp:18)
==869036==    by 0x1C6BB21: FreeVerb::~FreeVerb() (FreeVerb.cpp:5)
==869036==    by 0x1C6BB4D: FreeVerb::~FreeVerb() (FreeVerb.cpp:5)
==869036==    by 0x253B9BA: rack::app::ModuleWidget::setModule(rack::engine::Module*) (ModuleWidget.cpp:70)
==869036==    by 0x253B88E: rack::app::ModuleWidget::~ModuleWidget() (ModuleWidget.cpp:50)
==869036==    by 0x770B3F: rack::app::CardinalModuleWidget::~CardinalModuleWidget() (rack.hpp:25)
==869036==    by 0x1C6BABF: FreeVerbWidget::~FreeVerbWidget() (FreeVerb.cpp:127)
==869036==    by 0x1C6BADF: FreeVerbWidget::~FreeVerbWidget() (FreeVerb.cpp:127)
==869036==    by 0x6B3CB2: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:508)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==  Address 0x217adf80 is 0 bytes inside a block of size 6,468 alloc'd
==869036==    at 0x6E8F2F3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1CCD0D5: MLcomb::makebuffer(float*, int) (comb.hpp:32)
==869036==    by 0x1CCC888: MLrevmodel::init(float) (revmodel.cpp:62)
==869036==    by 0x1C698AF: FreeVerb::onSampleRateChange() (FreeVerb.cpp:71)
==869036==    by 0x770346: rack::engine::Module::onSampleRateChange(rack::engine::Module::SampleRateChangeEvent const&) (Module.hpp:409)
==869036==    by 0x24A46CB: rack::engine::Engine::addModule(rack::engine::Module*) (Engine.cpp:616)
==869036==    by 0x6B3B5F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:495)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 
```